### PR TITLE
Adding Batchelor Institute to list of partners in Organisation page.

### DIFF
--- a/content/about/organisation/index.md
+++ b/content/about/organisation/index.md
@@ -24,6 +24,7 @@ from the Australian Research Data Commons ({{< glossary_link display="ARDC" id="
 - **Queensland University of Technology (QUT) Digital Observatory**: [Dr Marissa Takahashi](https://www.qut.edu.au/about/our-people/academic-profiles/marissa.takahashi)
 - **AARNet**: [Adam Bell](https://www.linkedin.com/in/adamjohnbell/)
 - **First Languages Australia**: [Beau Williams](https://www.firstlanguages.org.au/about)
+- **Batchelor Institute of Indigenous Tertiary Education**: [Associate Professor Kathryn Gilbey](https://www.batchelor.edu.au/)
 
 <br>
 


### PR DESCRIPTION
Added Batchelor Institute & CI Kathryn Gilbey as a partner in the list of partners under 'Organisation'. 